### PR TITLE
Fixing Spellings and Typos

### DIFF
--- a/R/bdclean.R
+++ b/R/bdclean.R
@@ -1,12 +1,12 @@
 #' bdclean: Biodiversity Data Cleaning Workflows
 #'
 #' Biodiversity Data Cleaning Workflows using R would be helpful
-#' to clean biodiversity occurrence data typically downloaded form
+#' to clean biodiversity occurrence data typically downloaded from
 #' Global Biodiversity Information Facility (http://www.gbif.org/) or
 #' similar biodiversity data portals. There are several data cleaning
-#’ operations needed to be performed on most of the data downloaded
-#’ in order to achieve minimum quality to use the data further for any
-#’ analysis or modelling.
+#' operations needed to be performed on most of the data downloaded,
+#' in order to achieve minimum quality to use the data further for any
+#' analysis or modelling.
 #'
 #'@section Data cleaning:
 #'\itemize{
@@ -24,4 +24,3 @@
 #' @name bdclean
 NULL
 #> NULL
-

--- a/R/get_config.R
+++ b/R/get_config.R
@@ -1,6 +1,6 @@
 #' Get user inputs about data cleaning protocol to follow
 #'
-#' \code{get_config} asks user a set of questions and the answers are stoted
+#' \code{get_config} asks user a set of questions and the answers are stored
 #' in configuration variable. This variable will be used to clean the data
 #' depending on the responses
 #'


### PR DESCRIPTION
Fixed 3 spellings,
1) in bdclean.R roxygen comments started with **#’** instead of **#'**
2) in same file "data typically downloaded form" was changed to "... downloaded **from**"
3) in get_config.R "answers are **stoted**" was changed to "answers are **stored**"